### PR TITLE
define vm_size same as on Azure web console

### DIFF
--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -109,6 +109,15 @@ module VagrantPlugins
             "#{@vm_name}-service-"
           )
         end
+
+        aliases = {
+          'A0' => 'ExtraSmall',
+          'A1' => 'Small',
+          'A2' => 'Medium',
+          'A3' => 'Large',
+          'A4' => 'ExtraLarge',
+        }
+        @vm_size = aliases[@vm_size] if aliases.include?(@vm_size)
       end
 
       def merge(other)


### PR DESCRIPTION
On Azure web console, it can selected for vm_size from A0, A1, ... or A7 for Windows OS.
But an error occurs if specify A0 ... or A4 to vm_size.

I try out "Small" size, then succeeded to create VM that displays A0 as size on web console.
This behavior confused me...
