### PR TITLE
vm_virtual_network_name needs to be added to the config.rb

### DIFF
--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -63,7 +63,7 @@ module VagrantPlugins
           config.winrm_https_port.nil?
           options[:availability_set_name] = config.availability_set_name unless \
           config.availability_set_name.nil?
-          options[:vm_virtual_network_name] = config.vm_virtual_network_name unless \
+          options[:virtual_network_name] = config.vm_virtual_network_name unless \
           config.vm_virtual_network_name.nil?
 
           add_role = false

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
       attr_accessor :vm_image
       attr_accessor :vm_location
       attr_accessor :vm_affinity_group
+      attr_accessor :vm_virtual_network_name
 
       attr_accessor :cloud_service_name
       attr_accessor :deployment_name
@@ -59,6 +60,7 @@ module VagrantPlugins
         @vm_image = UNSET_VALUE
         @vm_location = UNSET_VALUE
         @vm_affinity_group = UNSET_VALUE
+        @vm_virtual_network_name = UNSET_VALUE
 
         @cloud_service_name = UNSET_VALUE
         @deployment_name = UNSET_VALUE
@@ -92,6 +94,7 @@ module VagrantPlugins
         @vm_image = nil if @vm_image == UNSET_VALUE
         @vm_location = nil if @vm_location == UNSET_VALUE
         @vm_affinity_group = nil if @vm_affinity_group == UNSET_VALUE
+        @vm_virtual_network_name = nil if @vm_virtual_network_name == UNSET_VALUE
 
         @cloud_service_name = nil if @cloud_service_name == UNSET_VALUE
         @deployment_name = nil if @deployment_name == UNSET_VALUE


### PR DESCRIPTION
```vm_virtual_network_name``` needs to be added to the ```config.rb```

For the ruby SDK it needs to be named ```virtual_network_name``` instead of ```vm_virtual_network_name``` in ```run_instance.rb```

Reference:
https://github.com/MSOpenTech/azure-sdk-for-ruby/blob/master/lib/azure/virtual_machine_management/virtual_machine_management_service.rb#L111