### PR TITLE
Upgrading vagrant dependency to v1.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.6.0'
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.7.2'
 end
 
 group :plugins do


### PR DESCRIPTION
This refers to #52 and updates the dependency to 1.7.2 . People need to update ;)

For reference:
https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec#L18

Maybe vagrant changed this prior to 1.7.2. But with the current bundler version you can build this project.