### PR TITLE
Fix winrm and ruby-azure patch loading

### DIFF
--- a/lib/vagrant-azure.rb
+++ b/lib/vagrant-azure.rb
@@ -13,13 +13,7 @@ module VagrantPlugins
     autoload :Errors, lib_path.join('errors')
     autoload :Driver, lib_path.join('driver')
 
-    Vagrant.plugin('2').manager.communicators[:winrm]
-    require 'kconv'
-    require lib_path.join('monkey_patch/azure')
-    require lib_path.join('monkey_patch/winrm')
-
     CLOUD_SERVICE_SEMAPHORE = Mutex.new
-
 
     # This returns the path to the source of this plugin.
     #

--- a/lib/vagrant-azure/plugin.rb
+++ b/lib/vagrant-azure/plugin.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
         # Setup logging and i18n
         setup_logging
         setup_i18n
+        apply_patches
 
         # Return the provider
         require_relative 'provider'
@@ -52,6 +53,14 @@ module VagrantPlugins
       command 'rdp' do
         require_relative 'command/rdp'
         VagrantPlugins::WinAzure::Command::RDP
+      end
+
+      def self.apply_patches
+        lib_path = Pathname.new(File.expand_path('../../vagrant-azure', __FILE__))
+        Vagrant.plugin('2').manager.communicators[:winrm]
+        require 'kconv'
+        require lib_path.join('monkey_patch/azure')
+        require lib_path.join('monkey_patch/winrm')
       end
 
       def self.setup_i18n


### PR DESCRIPTION
Loading of the winrm and ruby-azure patches were happening too early in the initialization of the vagrant-azure plugin. They need to be loaded when the plugin is being used, not when the plugin is loaded.

This should fix for: #46

*Things done:*
- Move winrm 1.1.3 and azure patch so they are loaded when provider is active