### PR TITLE
multiple vagrant-azure configs are incorrectly merged

### DIFF
--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -125,21 +125,6 @@ module VagrantPlugins
         end
       end
 
-      def merge(other)
-        super.tap do |result|
-          result.mgmt_certificate = other.mgmt_certificate || \
-            self.mgmt_certificate
-          result.mgmt_endpoint = other.mgmt_endpoint || \
-            self.mgmt_endpoint
-          result.subscription_id = other.subscription_id || \
-            self.subscription_id
-          result.storage_acct_name = other.storage_acct_name || \
-            self.storage_acct_name
-          result.storage_access_key = other.storage_access_key || \
-            self.storage_access_key
-        end
-      end
-
       def validate(machine)
         errors = _detected_errors
 


### PR DESCRIPTION
Vagrant allows to specify multiple declarations of the provider plugins and then merges it together .

Currently, configs are not merged and that contradicts to the [Vagrant load and merging section](<http://docs.vagrantup.com/v2/vagrantfile/>).
Test sample is below, its resulting config is empty while expected to see properties declared in both sections:
```
Vagrant.configure('2') do |config|
    config.vm.box = 'azure'

    config.vm.provider :azure do |azure|
        azure.mgmt_certificate = 'YOUR AZURE MANAGEMENT CERTIFICATE'
        azure.mgmt_endpoint = 'https://management.core.windows.net'
      # A lot of options here ....
    end

    config.vm.provider :azure do |azure|
    end
end
```

Per [Vagrant plugin seciton comments about merging](<http://docs.vagrantup.com/v2/plugins/configuration.html>) the default value for properties is custom `UNSET_VALUE` instead of `nil` so construction used in https://github.com/MSOpenTech/vagrant-azure/blob/master/lib/vagrant-azure/config.rb#L128 like
```
result.mgmt_certificate = other.mgmt_certificate || \
            self.mgmt_certificate
```
 is not appropriate as it always selects the property of the new config even unspecified.




#### Proposal
* remove lines 128-141 within file https://github.com/MSOpenTech/vagrant-azure/blob/master/lib/vagrant-azure/config.rb#L128L141  to use default merge implementation from vagrant https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/plugin/v2/config.rb#L45