### PR TITLE
Add support for DNS prefix dns_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For instructions on how to setup an Azure Active Directory Application see: http
 * `resource_group_name`: (Optional) Name of the resource group to use.
 * `location`: (Optional) Azure location to build the VM -- defaults to 'westus'
 * `vm_name`: (Optional) Name of the virtual machine
+* `dns_name`: (Optional) DNS prefix of the virtual machine -- full name will be [dns_name].[location].cloudapp.azure.com
 * `vm_password`: (Optional for *nix) Password for the VM -- This is not recommended for *nix deployments
 * `vm_size`: (Optional) VM size to be used -- defaults to 'Standard_D1'. See: https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/
 * `vm_image_urn`: (Optional) Name of the virtual machine image urn to use -- defaults to 'canonical:ubuntuserver:16.04.0-DAILY-LTS:latest'. See: https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-ps-findimage/

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ For instructions on how to setup an Azure Active Directory Application see: http
 * `vm_image_urn`: (Optional) Name of the virtual machine image urn to use -- defaults to 'canonical:ubuntuserver:16.04.0-DAILY-LTS:latest'. See: https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-ps-findimage/
 * `virtual_network_name`: (Optional) Name of the virtual network resource
 * `subnet_name`: (Optional) Name of the virtual network subnet resource
+* `private_ip_allocation_method`: (Optional) `Dynamic` (default) or `Static`
+* `private_ip`: (Optional) private IP address if `private_ip_allocation_method` is set to `Static`. Defaults to `10.0.0.4`
 * `instance_ready_timeout`: (Optional) The timeout to wait for an instance to become ready -- default 120 seconds.
 * `instance_check_interval`: (Optional) The interval to wait for checking an instance's state -- default 2 seconds.
 * `endpoint`: (Optional) The Azure Management API endpoint -- default 'https://management.azure.com' seconds -- ENV['AZURE_MANAGEMENT_ENDPOINT'].

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 This is a [Vagrant](http://www.vagrantup.com) 1.7.3+ plugin that adds [Microsoft Azure](https://azure.microsoft.com)
 provider to Vagrant, allowing Vagrant to control and provision machines in Microsoft Azure.
 
+## Dojo install
+
+```
+git clone https://github.com/ojacques/vagrant-azure.git
+cd vagrant-azure
+sudo apt-get install ruby
+gem build vagrant-azure.gemspec
+vagrant plugin install ./vagrant-azure-2.0.0.pre1.dojo.gem
+```
+
+Then, get an azure box in Vagrant:
+```
+vagrant box add azure https://github.com/azure/vagrant-azure/raw/v2.0/dummy.box
+```
+
 ## Usage
 
 [Download Vagrant](http://www.vagrantup.com/downloads.html)

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
           resource_group_name       = config.resource_group_name
           location                  = config.location
           vm_name                   = config.vm_name
+          dns_name                  = config.dns_name
           vm_password               = config.vm_password
           vm_size                   = config.vm_size
           vm_image_urn              = config.vm_image_urn
@@ -48,6 +49,7 @@ module VagrantPlugins
           env[:ui].info(" -- Resource Group Name: #{resource_group_name}")
           env[:ui].info(" -- Location: #{location}")
           env[:ui].info(" -- VM Name: #{vm_name}")
+          env[:ui].info(" -- DNS Prefix Name: #{dns_name}") if dns_name
           env[:ui].info(" -- VM Size: #{vm_size}")
           env[:ui].info(" -- Image URN: #{vm_image_urn}")
           env[:ui].info(" -- Virtual Network Name: #{virtual_network_name}") if virtual_network_name
@@ -65,7 +67,7 @@ module VagrantPlugins
           @logger.info("Time to fetch os image details: #{env[:metrics]['get_image_details']}")
 
           deployment_params = {
-            dnsLabelPrefix:       Haikunator.haikunate(100),
+            dnsLabelPrefix:       dns_name,
             vmSize:               vm_size,
             vmName:               vm_name,
             imagePublisher:       image_publisher,

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -38,6 +38,8 @@ module VagrantPlugins
           vm_size                   = config.vm_size
           vm_image_urn              = config.vm_image_urn
           virtual_network_name      = config.virtual_network_name
+          private_ip_allocation_method = config.private_ip_allocation_method
+          private_ip_address        = config.private_ip_address
           subnet_name               = config.subnet_name
           tcp_endpoints             = config.tcp_endpoints
           availability_set_name     = config.availability_set_name
@@ -53,6 +55,8 @@ module VagrantPlugins
           env[:ui].info(" -- VM Size: #{vm_size}")
           env[:ui].info(" -- Image URN: #{vm_image_urn}")
           env[:ui].info(" -- Virtual Network Name: #{virtual_network_name}") if virtual_network_name
+          env[:ui].info(" -- Private IP Allocation Method: #{private_ip_allocation_method}") if private_ip_allocation_method
+          env[:ui].info(" -- Private IP Address: #{private_ip_address}") if private_ip_allocation_method == 'Static'
           env[:ui].info(" -- Subnet Name: #{subnet_name}") if subnet_name
           env[:ui].info(" -- TCP Endpoints: #{tcp_endpoints}") if tcp_endpoints
           env[:ui].info(" -- Availability Set Name: #{availability_set_name}") if availability_set_name
@@ -75,7 +79,9 @@ module VagrantPlugins
             imageSku:             image_sku,
             imageVersion:         image_version,
             subnetName:           subnet_name,
-            virtualNetworkName:   virtual_network_name
+            virtualNetworkName:   virtual_network_name,
+            privateIPAllocationMethod:  private_ip_allocation_method,
+            privateIPAddress:     private_ip_address
           }
 
           if get_image_os(image_details) != 'Windows'

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -73,6 +73,16 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :subnet_name
 
+      # (Optional) Private IP allocation method: Dynamic (default) or Static
+      #
+      # @return [String]
+      attr_accessor :private_ip_allocation_method
+
+      # (Optional) Private IP Address if private IP allocation method is set to Static
+      #
+      # @return [String]
+      attr_accessor :private_ip_address
+
       # (Optional) TCP endpoints to open up for the VM
       #
       # @return [String]
@@ -112,6 +122,8 @@ module VagrantPlugins
         @vm_image_urn = UNSET_VALUE
         @virtual_network_name = UNSET_VALUE
         @subnet_name = UNSET_VALUE
+        @private_ip_allocation_method = UNSET_VALUE
+        @private_ip = UNSET_VALUE
         @tcp_endpoints = UNSET_VALUE
         @vm_size = UNSET_VALUE
         @availability_set_name = UNSET_VALUE
@@ -134,6 +146,8 @@ module VagrantPlugins
         @location = 'westus' if @location == UNSET_VALUE
         @virtual_network_name = nil if @virtual_network_name == UNSET_VALUE
         @subnet_name = nil if @subnet_name == UNSET_VALUE
+        @private_ip_allocation_method = 'Dynamic' if @private_ip_allocation_method == UNSET_VALUE
+        @private_ip = '10.0.0.4' if @private_ip == UNSET_VALUE
         @tcp_endpoints = nil if @tcp_endpoints == UNSET_VALUE
         @vm_size = 'Standard_D1' if @vm_size == UNSET_VALUE
         @availability_set_name = nil if @availability_set_name == UNSET_VALUE

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -43,6 +43,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :vm_name
 
+      # (Optional) DNS prefix name of the virtual machine
+      #
+      # @return [String]
+      attr_accessor :dns_name
+
       # Password for the VM -- This is not recommended for *nix deployments
       #
       # @return [String]
@@ -102,6 +107,7 @@ module VagrantPlugins
         @resource_group_name = UNSET_VALUE
         @location = UNSET_VALUE
         @vm_name = UNSET_VALUE
+        @dns_name = UNSET_VALUE
         @vm_password = UNSET_VALUE
         @vm_image_urn = UNSET_VALUE
         @virtual_network_name = UNSET_VALUE
@@ -121,6 +127,7 @@ module VagrantPlugins
         @client_secret = ENV['AZURE_CLIENT_SECRET'] if @client_secret == UNSET_VALUE
 
         @vm_name = Haikunator.haikunate(100) if @vm_name == UNSET_VALUE
+        @dns_name = Haikunator.haikunate(100) if @dns_name == UNSET_VALUE
         @resource_group_name = Haikunator.haikunate(100) if @resource_group_name == UNSET_VALUE
         @vm_password = nil if @vm_password == UNSET_VALUE
         @vm_image_urn = 'canonical:ubuntuserver:16.04.0-DAILY-LTS:latest' if @vm_image_urn == UNSET_VALUE

--- a/lib/vagrant-azure/version.rb
+++ b/lib/vagrant-azure/version.rb
@@ -4,6 +4,6 @@
 
 module VagrantPlugins
   module Azure
-    VERSION = '2.0.0.pre1'
+    VERSION = '2.0.0.pre1.dojo'
   end
 end

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -205,7 +205,6 @@
                "direction": "Inbound"
              }
             }
-          }
         ]
       }
     },

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -102,7 +102,7 @@
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'vagrant')]",
     "location": "[resourceGroup().location]",
-    "osDiskName": "osDisk1",
+    "osDiskName": "[concat(parameters('vmName'), 'OSDisk1')]",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",
     "vmStorageAccountContainerName": "vagrant-vhds",

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -83,6 +83,20 @@
       "metadata": {
         "description": "Name of the virtual network"
       }
+    },
+    "privateIPAllocationMethod": {
+      "type": "string",
+      "defaultValue": "Dynamic",
+      "metadata": {
+        "description": "Private IP Allocation method"
+      }
+    },
+    "privateIPAddress": {
+      "type": "string",
+      "defaultValue": "10.0.0.4",
+      "metadata": {
+        "description": "Private IP Address"
+      }
     }
   },
   "variables": {
@@ -95,6 +109,8 @@
     "nicName": "[concat(parameters('vmName'), '-vagrantNIC')]",
     "publicIPAddressName": "[concat(parameters('vmName'), '-vagrantPublicIP')]",
     "publicIPAddressType": "Dynamic",
+    "privateIPAllocationMethod": "[parameters('privateIPAllocationMethod')]",
+    "privateIPAddress": "[parameters('privateIPAddress')]",
     "storageAccountType": "Standard_LRS",
     "networkSecurityGroupName": "[concat(parameters('vmName'), '-vagrantNSG')]",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
@@ -189,7 +205,8 @@
           {
             "name": "ipconfig1",
             "properties": {
-              "privateIPAllocationMethod": "Dynamic",
+              "privateIPAllocationMethod": "[variables('privateIPAllocationMethod')]",
+              "privateIPAddress":"[variables('privateIPAddress')]",
               "publicIPAddress": {
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               },

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -189,6 +189,7 @@
               "access": "Allow",
               "priority": 153,
              "direction": "Inbound"
+            }
            },
            {
              "name": "http4_rule",
@@ -203,6 +204,7 @@
                "priority": 163,
                "direction": "Inbound"
              }
+            }
           }
         ]
       }

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -176,6 +176,20 @@
               "priority": 143,
              "direction": "Inbound"
             }
+          },
+          {
+            "name": "http3_rule",
+            "properties": {
+              "description": "http 3 port 18090.",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "18090",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 153,
+             "direction": "Inbound"
+            }
           }
         ]
       }

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -147,13 +147,14 @@
               "access": "Allow",
               "priority": 123,
               "direction": "Inbound"
+            }
           },
           {
             "name": "http_rule",
             "properties": {
               "description": "http inbound on port 80.",
               "protocol": "Tcp",
-             "sourcePortRange": "*",
+              "sourcePortRange": "*",
               "destinationPortRange": "80",
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -103,8 +103,8 @@
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'vagrant')]",
     "location": "[resourceGroup().location]",
     "osDiskName": "[concat(parameters('vmName'), 'OSDisk1')]",
-    "addressPrefix": "10.0.0.0/16",
-    "subnetPrefix": "10.0.0.0/24",
+    "addressPrefix": "10.211.55.0/24",
+    "subnetPrefix": "10.211.55.0/24",
     "vmStorageAccountContainerName": "vagrant-vhds",
     "nicName": "[concat(parameters('vmName'), '-vagrantNIC')]",
     "publicIPAddressName": "[concat(parameters('vmName'), '-vagrantPublicIP')]",
@@ -147,6 +147,33 @@
               "access": "Allow",
               "priority": 123,
               "direction": "Inbound"
+          },
+          {
+            "name": "http_rule",
+            "properties": {
+              "description": "http inbound on port 80.",
+              "protocol": "Tcp",
+             "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 133,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "http2_rule",
+            "properties": {
+              "description": "http 2 port 8080.",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8080",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 143,
+             "direction": "Inbound"
             }
           }
         ]

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -189,7 +189,20 @@
               "access": "Allow",
               "priority": 153,
              "direction": "Inbound"
-            }
+           },
+           {
+             "name": "http4_rule",
+             "properties": {
+               "description": "http 4 port 9200.",
+               "protocol": "Tcp",
+               "sourcePortRange": "*",
+               "destinationPortRange": "9200",
+               "sourceAddressPrefix": "*",
+               "destinationAddressPrefix": "*",
+               "access": "Allow",
+               "priority": 163,
+               "direction": "Inbound"
+             }
           }
         ]
       }


### PR DESCRIPTION
This adds support for custom DNS name prefix. 
Without this PR, DNS prefix is generated automatically. With this PR, DNS prefix is generated automatically if dns_name is not set, and dns_name is used if it is set.

This helps having a workaround for issue #71. 
