### PR TITLE
Update to use version 0.7.0 of the ARM SDK

### DIFF
--- a/lib/vagrant-azure/action/read_ssh_info.rb
+++ b/lib/vagrant-azure/action/read_ssh_info.rb
@@ -24,9 +24,9 @@ module VagrantPlugins
         def read_ssh_info(azure, env)
           return nil if env[:machine].id.nil?
           parsed = parse_machine_id(env[:machine].id)
-          public_ip = azure.network.public_ipaddresses.get(parsed[:group], "#{parsed[:name]}-vagrantPublicIP").value!.body
+          public_ip = azure.network.public_ipaddresses.get(parsed[:group], "#{parsed[:name]}-vagrantPublicIP")
 
-          {:host => public_ip.properties.dns_settings.fqdn, :port => 22}
+          {:host => public_ip.dns_settings.fqdn, :port => 22}
         end
       end
     end

--- a/lib/vagrant-azure/action/read_state.rb
+++ b/lib/vagrant-azure/action/read_state.rb
@@ -29,9 +29,9 @@ module VagrantPlugins
           parsed = parse_machine_id(machine.id)
           vm = nil
           begin
-            vm = azure.compute.virtual_machines.get(parsed[:group], parsed[:name], 'instanceView').value!.body
+            vm = azure.compute.virtual_machines.get(parsed[:group], parsed[:name], 'instanceView')
           rescue MsRestAzure::AzureOperationError => ex
-            if vm.nil? || tearing_down?(vm.properties.instance_view.statuses)
+            if vm.nil? || tearing_down?(vm.instance_view.statuses)
               # The machine can't be found
               @logger.info('Machine not found or terminated, assuming it got destroyed.')
               machine.id = nil
@@ -40,7 +40,7 @@ module VagrantPlugins
           end
 
           # Return the state
-          power_state(vm.properties.instance_view.statuses)
+          power_state(vm.instance_view.statuses)
         end
 
       end

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -144,20 +144,20 @@ module VagrantPlugins
         end
 
         def get_image_os(image_details)
-          image_details.properties.os_disk_image.operating_system
+          image_details.os_disk_image.operating_system
         end
 
         def get_image_details(azure, location, publisher, offer, sku, version)
           if version == 'latest'
-            latest = azure.compute.virtual_machine_images.list(location, publisher, offer, sku).value!.body.last
-            azure.compute.virtual_machine_images.get(location, publisher, offer, sku, latest.name).value!.body
+            latest = azure.compute.virtual_machine_images.list(location, publisher, offer, sku)
+            azure.compute.virtual_machine_images.get(location, publisher, offer, sku, latest.name)
           else
-            azure.compute.virtual_machine_images.get(location, publisher, offer, sku, version).value!.body
+            azure.compute.virtual_machine_images.get(location, publisher, offer, sku, version)
           end
         end
 
         def put_deployment(azure, rg_name, params)
-          azure.resources.deployments.create_or_update(rg_name, 'vagrant', params).value!.body
+          azure.resources.deployments.create_or_update(rg_name, 'vagrant', params)
         end
 
         def put_resource_group(azure, name, location)
@@ -165,7 +165,7 @@ module VagrantPlugins
             rg.location = location
           end
 
-          azure.resources.resource_groups.create_or_update(name, params).value!.body
+          azure.resources.resource_groups.create_or_update(name, params)
         end
 
         # This method generates the deployment template

--- a/lib/vagrant-azure/action/start_instance.rb
+++ b/lib/vagrant-azure/action/start_instance.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
             env[:ui].info(I18n.t('vagrant_azure.waiting_for_ready'))
 
             task = await_true(env) do |vm|
-              running?(vm.properties.instance_view.statuses)
+              running?(vm.instance_view.statuses)
             end
 
             if task.value

--- a/lib/vagrant-azure/action/stop_instance.rb
+++ b/lib/vagrant-azure/action/stop_instance.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
               env[:ui].info(I18n.t('vagrant_azure.waiting_for_stop'))
 
               task = await_true(env) do |vm|
-                stopped?(vm.properties.instance_view.statuses)
+                stopped?(vm.instance_view.statuses)
               end
 
               if task.value

--- a/lib/vagrant-azure/action/terminate_instance.rb
+++ b/lib/vagrant-azure/action/terminate_instance.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
 
           begin
             env[:ui].info(I18n.t('vagrant_azure.terminating', parsed))
-            env[:azure_arm_service].resources.resource_groups.delete(parsed[:group]).value!.body
+            env[:azure_arm_service].resources.resource_groups.delete(parsed[:group])
           rescue MsRestAzure::AzureOperationError => ex
             unless ex.response.status == 404
               raise ex

--- a/lib/vagrant-azure/util/vm_await.rb
+++ b/lib/vagrant-azure/util/vm_await.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
             end
 
             count += 1
-            vm = azure.compute.virtual_machines.get(parsed[:group], parsed[:name], 'instanceView').value!.body
+            vm = azure.compute.virtual_machines.get(parsed[:group], parsed[:name], 'instanceView')
             if yield(vm)
               task.shutdown
               true

--- a/vagrant-azure.gemspec
+++ b/vagrant-azure.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  s.add_runtime_dependency 'azure_mgmt_resources',  '~>0.2.1'
-  s.add_runtime_dependency 'azure_mgmt_compute',    '~>0.2.1'
-  s.add_runtime_dependency 'azure_mgmt_network',    '~>0.2.1'
-  s.add_runtime_dependency 'azure_mgmt_storage',    '~>0.2.1'
+  s.add_runtime_dependency 'azure_mgmt_resources',  '>=0.7.0'
+  s.add_runtime_dependency 'azure_mgmt_compute',    '>=0.7.0'
+  s.add_runtime_dependency 'azure_mgmt_network',    '>=0.7.0'
+  s.add_runtime_dependency 'azure_mgmt_storage',    '>=0.7.0'
   s.add_runtime_dependency 'haikunator',            '~>1.1'
 
   s.add_development_dependency 'bundler',           '~>1.9'


### PR DESCRIPTION
For vagrant-azure to be useful, it needs to keep up with the SDK. This pull request brings it to be compatible with the latest release of the SDK and this is the patch that is shipping in Debian to allow the latest SDK to be used.
