### PR TITLE
Fix rubocop scanned out issue: use _ as an argument name to indicate that it won't be used

### DIFF
--- a/lib/vagrant-azure/action/connect_azure.rb
+++ b/lib/vagrant-azure/action/connect_azure.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
   module Azure
     module Action
       class ConnectAzure
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::connect_azure')
         end

--- a/lib/vagrant-azure/action/is_created.rb
+++ b/lib/vagrant-azure/action/is_created.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
   module Azure
     module Action
       class IsCreated
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
         end
 

--- a/lib/vagrant-azure/action/is_stopped.rb
+++ b/lib/vagrant-azure/action/is_stopped.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
   module Azure
     module Action
       class IsStopped
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
         end
 

--- a/lib/vagrant-azure/action/message_already_created.rb
+++ b/lib/vagrant-azure/action/message_already_created.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
   module Azure
     module Action
       class MessageAlreadyCreated
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
         end
 

--- a/lib/vagrant-azure/action/message_not_created.rb
+++ b/lib/vagrant-azure/action/message_not_created.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
   module Azure
     module Action
       class MessageNotCreated
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
         end
 

--- a/lib/vagrant-azure/action/message_will_not_destroy.rb
+++ b/lib/vagrant-azure/action/message_will_not_destroy.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
   module Azure
     module Action
       class MessageWillNotDestroy
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
         end
 

--- a/lib/vagrant-azure/action/read_ssh_info.rb
+++ b/lib/vagrant-azure/action/read_ssh_info.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
       class ReadSSHInfo
         include VagrantPlugins::Azure::Util::MachineIdHelper
 
-        def initialize(app, env, port = 22)
+        def initialize(app, _, port = 22)
           @app = app
           @port = port
           @logger = Log4r::Logger.new('vagrant_azure::action::read_ssh_info')

--- a/lib/vagrant-azure/action/read_state.rb
+++ b/lib/vagrant-azure/action/read_state.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
         include VagrantPlugins::Azure::Util::VMStatusTranslator
         include VagrantPlugins::Azure::Util::MachineIdHelper
 
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::read_state')
         end

--- a/lib/vagrant-azure/action/restart_vm.rb
+++ b/lib/vagrant-azure/action/restart_vm.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
       class RestartVM
         include VagrantPlugins::Azure::Util::MachineIdHelper
 
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::restart_vm')
         end

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
         include Vagrant::Util::Retryable
         include VagrantPlugins::Azure::Util::MachineIdHelper
 
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::run_instance')
         end
@@ -34,7 +34,6 @@ module VagrantPlugins
           location                  = config.location
           admin_user_name           = machine.config.ssh.username
           vm_name                   = config.vm_name
-          vm_password               = config.vm_password
           vm_size                   = config.vm_size
           vm_image_urn              = config.vm_image_urn
           virtual_network_name      = config.virtual_network_name
@@ -85,7 +84,7 @@ module VagrantPlugins
               raise I18n.t('vagrant_azure.private_key_not_specified')
             end
 
-            paths_to_pub = private_key_paths.map{ |k| File.expand_path( k + '.pub') }.select{ |p| File.exists?(p) }
+            paths_to_pub = private_key_paths.map{ |k| File.expand_path( k + '.pub') }.select{ |p| File.exist?(p) }
             raise I18n.t('vagrant_azure.public_key_path_private_key', private_key_paths.join(', ')) if paths_to_pub.empty?
             deployment_params.merge!(sshKeyData: File.read(paths_to_pub.first))
           end

--- a/lib/vagrant-azure/action/start_instance.rb
+++ b/lib/vagrant-azure/action/start_instance.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
         include VagrantPlugins::Azure::Util::VMStatusTranslator
         include VagrantPlugins::Azure::Util::VMAwait
 
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::start_instance')
         end

--- a/lib/vagrant-azure/action/stop_instance.rb
+++ b/lib/vagrant-azure/action/stop_instance.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
         include VagrantPlugins::Azure::Util::VMAwait
         include VagrantPlugins::Azure::Util::VMStatusTranslator
 
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::stop_instance')
         end

--- a/lib/vagrant-azure/action/terminate_instance.rb
+++ b/lib/vagrant-azure/action/terminate_instance.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
       class TerminateInstance
         include VagrantPlugins::Azure::Util::MachineIdHelper
 
-        def initialize(app, env)
+        def initialize(app, _)
           @app = app
           @logger = Log4r::Logger.new('vagrant_azure::action::terminate_instance')
         end

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -135,7 +135,7 @@ module VagrantPlugins
         @instance_check_interval = 2 if @instance_check_interval == UNSET_VALUE
       end
 
-      def validate(machine)
+      def validate(_)
         errors = _detected_errors
 
         # Azure connection properties related validation.

--- a/lib/vagrant-azure/plugin.rb
+++ b/lib/vagrant-azure/plugin.rb
@@ -77,7 +77,6 @@ module VagrantPlugins
           logger = Log4r::Logger.new('vagrant_azure')
           logger.outputters = Log4r::Outputter.stderr
           logger.level = level
-          logger = nil
         end
       end
     end


### PR DESCRIPTION
Fix rubocop scanned out issue: use _ as an argument name to indicate that it won't be used