### PR TITLE
Support Windows & WinRM

### DIFF
--- a/lib/vagrant-azure/action.rb
+++ b/lib/vagrant-azure/action.rb
@@ -75,6 +75,16 @@ module VagrantPlugins
         end
       end
 
+      # This action is called to read the WinRM info of the machine. The
+      # resulting state is expected to be put into the `:machine_winrm_info` key.
+      def self.action_read_winrm_info
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectAzure
+          b.use ReadWinrmInfo
+        end
+      end
+
       # This action is called to read the state of the machine. The
       # resulting state is expected to be put into the `:machine_state_id`
       # key.
@@ -178,6 +188,7 @@ module VagrantPlugins
       autoload :MessageNotCreated, action_root.join('message_not_created')
       autoload :MessageWillNotDestroy, action_root.join('message_will_not_destroy')
       autoload :ReadSSHInfo, action_root.join('read_ssh_info')
+      autoload :ReadWinrmInfo, action_root.join('read_winrm_info')
       autoload :ReadState, action_root.join('read_state')
       autoload :RestartVM, action_root.join('restart_vm')
       autoload :RunInstance, action_root.join('run_instance')

--- a/lib/vagrant-azure/action/read_winrm_info.rb
+++ b/lib/vagrant-azure/action/read_winrm_info.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
           env[:machine].config.winrm.ssl_peer_verification = false
           env[:machine].config.winrm.transport = :ssl
 
-          {:host => public_ip.properties.dns_settings.fqdn, :port => 5986}
+          {:host => public_ip.properties.dns_settings.fqdn, :port => env[:machine].config.winrm.port}
         end
       end
     end

--- a/lib/vagrant-azure/action/read_winrm_info.rb
+++ b/lib/vagrant-azure/action/read_winrm_info.rb
@@ -1,0 +1,40 @@
+#--------------------------------------------------------------------------
+# Copyright (c) Microsoft Open Technologies, Inc.
+# All Rights Reserved.  Licensed under the Apache License, Version 2.0.
+# See License.txt in the project root for license information.
+#--------------------------------------------------------------------------
+require 'log4r'
+require 'vagrant-azure/util/machine_id_helper'
+
+module VagrantPlugins
+  module Azure
+    module Action
+      class ReadWinrmInfo
+        include VagrantPlugins::Azure::Util::MachineIdHelper
+
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new('vagrant_azure::action::read_winrm_info')
+        end
+
+        def call(env)
+          if env[:machine].config.vm.guest == :windows
+            env[:machine_winrm_info] = read_winrm_info(env[:azure_arm_service], env)
+          end
+
+          @app.call(env)
+        end
+
+        def read_winrm_info(azure, env)
+          return nil if env[:machine].id.nil?
+          parsed = parse_machine_id(env[:machine].id)
+          public_ip = azure.network.public_ipaddresses.get(parsed[:group], "#{parsed[:name]}-vagrantPublicIP").value!.body
+          env[:machine].config.winrm.ssl_peer_verification = false
+          env[:machine].config.winrm.transport = :ssl
+
+          {:host => public_ip.properties.dns_settings.fqdn, :port => 5986}
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-azure/action/read_winrm_info.rb
+++ b/lib/vagrant-azure/action/read_winrm_info.rb
@@ -29,8 +29,6 @@ module VagrantPlugins
           return nil if env[:machine].id.nil?
           parsed = parse_machine_id(env[:machine].id)
           public_ip = azure.network.public_ipaddresses.get(parsed[:group], "#{parsed[:name]}-vagrantPublicIP").value!.body
-          env[:machine].config.winrm.ssl_peer_verification = false
-          env[:machine].config.winrm.transport = :ssl
 
           {:host => public_ip.properties.dns_settings.fqdn, :port => env[:machine].config.winrm.port}
         end

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -43,6 +43,7 @@ module VagrantPlugins
           availability_set_name     = config.availability_set_name
           admin_user_name           = config.admin_username
           admin_password            = config.admin_password
+          winrm_port                = config.winrm_port
 
           # Launch!
           env[:ui].info(I18n.t('vagrant_azure.launching_instance'))
@@ -101,13 +102,14 @@ module VagrantPlugins
           else
             env[:machine].config.vm.communicator = :winrm
              #this should probably be parameterised and passed into the template
-            machine.config.winrm.port = 5986
+            machine.config.winrm.port = winrm_port
             machine.config.winrm.username = admin_user_name
             machine.config.winrm.password = admin_password
             communicator_message = 'vagrant_azure.waiting_for_winrm'
             windows_params = {
               adminUsername:  admin_user_name,
               adminPassword:  admin_password,
+              winRmPort:      winrm_port
             }
             deployment_params.merge!(windows_params)
           end

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -51,7 +51,7 @@ module VagrantPlugins
           env[:ui].info(" -- Resource Group Name: #{resource_group_name}")
           env[:ui].info(" -- Location: #{location}")
           env[:ui].info(" -- SSH User Name: #{ssh_user_name}") if ssh_user_name
-          env[:ui].info(" -- Admin Username: #{adminUsername}") if admin_user_name
+          env[:ui].info(" -- Admin Username: #{admin_user_name}") if admin_user_name
           env[:ui].info(" -- VM Name: #{vm_name}")
           env[:ui].info(" -- VM Size: #{vm_size}")
           env[:ui].info(" -- Image URN: #{vm_image_urn}")

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
           availability_set_name     = config.availability_set_name
           admin_user_name           = config.admin_username
           admin_password            = config.admin_password
-          winrm_port                = config.winrm_port
+          winrm_port                = machine.config.winrm.port
 
           # Launch!
           env[:ui].info(I18n.t('vagrant_azure.launching_instance'))

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -46,6 +46,7 @@ module VagrantPlugins
           winrm_port                     = machine.config.winrm.port
           winrm_install_self_signed_cert = config.winrm_install_self_signed_cert
           dns_label_prefix               = Haikunator.haikunate(100)
+          deployment_template            = config.deployment_template
 
           # Launch!
           env[:ui].info(I18n.t('vagrant_azure.launching_instance'))
@@ -93,7 +94,8 @@ module VagrantPlugins
             winrm_install_self_signed_cert: winrm_install_self_signed_cert,
             winrm_port:                     winrm_port,
             dns_label_prefix:               dns_label_prefix,
-            location:                       location
+            location:                       location,
+            deployment_template:            deployment_template
           }
 
           if operating_system != 'Windows'
@@ -214,7 +216,11 @@ module VagrantPlugins
         def build_deployment_params(template_params, deployment_params)
           params = ::Azure::ARM::Resources::Models::Deployment.new
           params.properties = ::Azure::ARM::Resources::Models::DeploymentProperties.new
-          params.properties.template = JSON.parse(render_deployment_template(template_params))
+          if (template_params[:deployment_template].nil?)
+            params.properties.template = JSON.parse(render_deployment_template(template_params))
+          else
+            params.properties.template = JSON.parse(template_params[:deployment_template])
+          end
           params.properties.mode = ::Azure::ARM::Resources::Models::DeploymentMode::Incremental
           params.properties.parameters = build_parameters(deployment_params)
           params

--- a/lib/vagrant-azure/action/terminate_instance.rb
+++ b/lib/vagrant-azure/action/terminate_instance.rb
@@ -20,7 +20,9 @@ module VagrantPlugins
 
           begin
             env[:ui].info(I18n.t('vagrant_azure.terminating', parsed))
+            env[:ui].info('Deleting resource group')
             env[:azure_arm_service].resources.resource_groups.delete(parsed[:group]).value!.body
+            env[:ui].info('Resource group deleted...')
           rescue MsRestAzure::AzureOperationError => ex
             unless ex.response.status == 404
               raise ex

--- a/lib/vagrant-azure/capabilities/winrm.rb
+++ b/lib/vagrant-azure/capabilities/winrm.rb
@@ -1,0 +1,12 @@
+module VagrantPlugins
+  module Azure
+    module Cap
+      class WinRM
+        def self.winrm_info(machine)
+          env = machine.action('read_winrm_info')
+          env[:machine_winrm_info]
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -93,7 +93,6 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :endpoint
 
-
       # (Optional - requrired for Windows) The admin username for Windows templates -- ENV['AZURE_VM_ADMIN_USERNAME']
       #
       # @return [String]
@@ -103,6 +102,11 @@ module VagrantPlugins
       #
       # @return [String]
       attr_accessor :admin_password
+
+      # (Optional) Whether to automatically install a self-signed cert and open the firewall port for winrm over https -- default true
+      #
+      # @return [String]
+      attr_accessor :winrm_install_self_signed_cert
 
       def initialize
         @tenant_id = UNSET_VALUE
@@ -124,6 +128,7 @@ module VagrantPlugins
         @instance_check_interval = UNSET_VALUE
         @admin_username = UNSET_VALUE
         @admin_password = UNSET_VALUE
+        @winrm_install_self_signed_cert = UNSET_VALUE
       end
 
       def finalize!
@@ -149,6 +154,7 @@ module VagrantPlugins
 
         @admin_username = ENV['AZURE_VM_ADMIN_USERNAME'] if @admin_username == UNSET_VALUE
         @admin_password = ENV['AZURE_VM_ADMIN_PASSWORD'] if @admin_password == UNSET_VALUE
+        @winrm_install_self_signed_cert = true if @winrm_install_self_signed_cert = UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -104,6 +104,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :admin_password
 
+      # (Optional) The port used for WinRM -- default 5986
+      #
+      # @return [String]
+      attr_accessor :winrm_port
+
       def initialize
         @tenant_id = UNSET_VALUE
         @client_id = UNSET_VALUE
@@ -124,6 +129,7 @@ module VagrantPlugins
         @instance_check_interval = UNSET_VALUE
         @admin_username = UNSET_VALUE
         @admin_password = UNSET_VALUE
+        @winrm_port = UNSET_VALUE
       end
 
       def finalize!
@@ -149,6 +155,7 @@ module VagrantPlugins
 
         @admin_username = ENV['AZURE_VM_ADMIN_USERNAME'] if @admin_username == UNSET_VALUE
         @admin_password = ENV['AZURE_VM_ADMIN_PASSWORD'] if @admin_password == UNSET_VALUE
+        @winrm_port = 5986 if @winrm_port == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -104,11 +104,6 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :admin_password
 
-      # (Optional) The port used for WinRM -- default 5986
-      #
-      # @return [String]
-      attr_accessor :winrm_port
-
       def initialize
         @tenant_id = UNSET_VALUE
         @client_id = UNSET_VALUE
@@ -129,7 +124,6 @@ module VagrantPlugins
         @instance_check_interval = UNSET_VALUE
         @admin_username = UNSET_VALUE
         @admin_password = UNSET_VALUE
-        @winrm_port = UNSET_VALUE
       end
 
       def finalize!
@@ -155,7 +149,6 @@ module VagrantPlugins
 
         @admin_username = ENV['AZURE_VM_ADMIN_USERNAME'] if @admin_username == UNSET_VALUE
         @admin_password = ENV['AZURE_VM_ADMIN_PASSWORD'] if @admin_password == UNSET_VALUE
-        @winrm_port = 5986 if @winrm_port == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -105,8 +105,13 @@ module VagrantPlugins
 
       # (Optional) Whether to automatically install a self-signed cert and open the firewall port for winrm over https -- default true
       #
-      # @return [String]
+      # @return [Bool]
       attr_accessor :winrm_install_self_signed_cert
+
+      # (Optional - Required for Windows) The admin username for Windows templates -- ENV['AZURE_VM_ADMIN_PASSWORD']
+      #
+      # @return [String]
+      attr_accessor :deployment_template
 
       def initialize
         @tenant_id = UNSET_VALUE
@@ -129,6 +134,7 @@ module VagrantPlugins
         @admin_username = UNSET_VALUE
         @admin_password = UNSET_VALUE
         @winrm_install_self_signed_cert = UNSET_VALUE
+        @deployment_template = UNSET_VALUE
       end
 
       def finalize!
@@ -154,7 +160,8 @@ module VagrantPlugins
 
         @admin_username = ENV['AZURE_VM_ADMIN_USERNAME'] if @admin_username == UNSET_VALUE
         @admin_password = ENV['AZURE_VM_ADMIN_PASSWORD'] if @admin_password == UNSET_VALUE
-        @winrm_install_self_signed_cert = true if @winrm_install_self_signed_cert = UNSET_VALUE
+        @winrm_install_self_signed_cert = true if @winrm_install_self_signed_cert == UNSET_VALUE
+        @deployment_template = nil if @deployment_template == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -93,6 +93,17 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :endpoint
 
+
+      # (Optional - requrired for Windows) The admin username for Windows templates -- ENV['AZURE_VM_ADMIN_USERNAME']
+      #
+      # @return [String]
+      attr_accessor :admin_username
+
+      # (Optional - Required for Windows) The admin username for Windows templates -- ENV['AZURE_VM_ADMIN_PASSWORD']
+      #
+      # @return [String]
+      attr_accessor :admin_password
+
       def initialize
         @tenant_id = UNSET_VALUE
         @client_id = UNSET_VALUE
@@ -111,6 +122,8 @@ module VagrantPlugins
         @availability_set_name = UNSET_VALUE
         @instance_ready_timeout = UNSET_VALUE
         @instance_check_interval = UNSET_VALUE
+        @admin_username = UNSET_VALUE
+        @admin_password = UNSET_VALUE
       end
 
       def finalize!
@@ -133,6 +146,9 @@ module VagrantPlugins
 
         @instance_ready_timeout = 120 if @instance_ready_timeout == UNSET_VALUE
         @instance_check_interval = 2 if @instance_check_interval == UNSET_VALUE
+
+        @admin_username = ENV['AZURE_VM_ADMIN_USERNAME'] if @admin_username == UNSET_VALUE
+        @admin_password = ENV['AZURE_VM_ADMIN_PASSWORD'] if @admin_password == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-azure/plugin.rb
+++ b/lib/vagrant-azure/plugin.rb
@@ -37,6 +37,11 @@ module VagrantPlugins
         Provider
       end
 
+      provider_capability(:azure, :winrm_info) do
+        require_relative 'capabilities/winrm'
+        VagrantPlugins::Azure::Cap::WinRM
+      end
+
       def self.setup_i18n
         I18n.load_path << File.expand_path(
           'locales/en.yml',

--- a/lib/vagrant-azure/provider.rb
+++ b/lib/vagrant-azure/provider.rb
@@ -10,6 +10,12 @@ module VagrantPlugins
 
       def initialize(machine)
         @machine = machine
+
+        # Load the driver
+        machine_id_changed
+
+        @machine.config.winrm.password = @machine.provider_config.admin_password
+        @machine.config.winrm.username = @machine.provider_config.admin_username
       end
 
       def action(name)
@@ -27,6 +33,11 @@ module VagrantPlugins
         # key in the environment.
         env = @machine.action('read_ssh_info')
         env[:machine_ssh_info]
+      end
+
+      def winrm_info
+        env = @machine.action('read_winrm_info')
+        env[:machine_winrm_info]
       end
 
       def state

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -92,6 +92,8 @@ en:
         you can run `vagrant destroy`.
     waiting_for_ssh: |-
       Waiting for SSH to become available...
+    waiting_for_winrm: |-
+      Waiting for WinRM to become available...
     ready: |-
       Machine is booted and ready for use!
     public_key_path_private_key: |-

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -108,7 +108,9 @@
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
-    "apiVersion": "2015-06-15"
+    "apiVersion": "2015-06-15",
+    "singleQuote": "'",
+    "doubleQuote": "\""
   },
   "resources": [
     {
@@ -250,30 +252,7 @@
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],
       <% if operating_system == 'Windows' %>
-      "resources": [
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('vmName'),'/WinRMCustomScriptExtension')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
-            ],
-            "properties": {
-             "publisher": "Microsoft.Compute",
-             "type": "CustomScriptExtension",
-               "typeHandlerVersion": "1.4",
-               "settings": {
-               "fileUris": [
-                    "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-winrm-windows/ConfigureWinRM.ps1",
-                    "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-winrm-windows/makecert.exe",
-                    "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-winrm-windows/winrmconf.cmd"
-                  ],
-               "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -file ConfigureWinRM.ps1 *.',resourceGroup().location,'.cloudapp.azure.com')]"
-               }
-           }
-        }
-      ],
+      <%= self_signed_cert_resource %>
       <% end %>
       "properties": {
         "hardwareProfile": {

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -16,13 +16,14 @@
         "description": "Password for the Virtual Machine (only used on Windows)"
       }
     },
-    <% end %>
+    <% else %>
     "sshKeyData": {
       "type": "string",
       "metadata": {
         "description": "SSH rsa public key file as a string."
       }
     },
+    <% end %>
     "dnsLabelPrefix": {
       "type": "string",
       "metadata": {
@@ -119,6 +120,36 @@
       "location": "[variables('location')]",
       "properties": {
         "securityRules": [
+          <% if operating_system == 'Windows' %>
+          {
+            "name": "rdp_rule",
+            "properties": {
+              "description": "Enable Inbound RDP",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3389",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 123,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "winrm_rule",
+            "properties": {
+              "description": "Enable Inbound WinRM",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "5986",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 124,
+              "direction": "Inbound"
+            }
+          }
+          <% else %>
           {
             "name": "ssh_rule",
             "properties": {
@@ -133,6 +164,7 @@
               "direction": "Inbound"
             }
           }
+          <% end %>
         ]
       }
     },
@@ -210,6 +242,32 @@
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],
+      <% if operating_system == 'Windows' %>
+      "resources": [
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('vmName'),'/WinRMCustomScriptExtension')]",
+            "apiVersion": "[variables('apiVersion')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            ],
+            "properties": {
+             "publisher": "Microsoft.Compute",
+             "type": "CustomScriptExtension",
+               "typeHandlerVersion": "1.4",
+               "settings": {
+               "fileUris": [
+                    "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-winrm-windows/ConfigureWinRM.ps1",
+                    "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-winrm-windows/makecert.exe",
+                    "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-winrm-windows/winrmconf.cmd"
+                  ],
+               "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -file ConfigureWinRM.ps1 *.',resourceGroup().location,'.cloudapp.azure.com')]"
+               }
+           }
+        }
+      ],
+      <% end %>
       "properties": {
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
@@ -217,6 +275,9 @@
         "osProfile": {
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
+          <% if operating_system == 'Windows' %>
+          "adminPassword": "[parameters('adminPassword')]"
+          <% else %>
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
             "ssh": {
@@ -228,6 +289,7 @@
               ]
             }
           }
+          <% end %>
         },
         "storageProfile": {
           "imageReference": {

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -11,7 +11,7 @@
     },
     <% if operating_system == 'Windows' %>
     "adminPassword": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Password for the Virtual Machine (only used on Windows)"
       }

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -84,6 +84,13 @@
       "metadata": {
         "description": "Name of the virtual network"
       }
+    },
+    "winRmPort": {
+      "type": "int",
+      "defaultValue": 5986,
+      "metadata": {
+        "description": "WinRM port"
+      }
     }
   },
   "variables": {
@@ -141,7 +148,7 @@
               "description": "Enable Inbound WinRM",
               "protocol": "Tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "5986",
+              "destinationPortRange": "[parameters('winRmPort')]",
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",

--- a/templates/arm/selfsignedcert.json.erb
+++ b/templates/arm/selfsignedcert.json.erb
@@ -1,0 +1,19 @@
+      "resources": [
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('vmName'),'/WinRMCustomScriptExtension')]",
+            "apiVersion": "[variables('apiVersion')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            ],
+            "properties": {
+             "publisher": "Microsoft.Compute",
+             "type": "CustomScriptExtension",
+               "typeHandlerVersion": "1.4",
+               "settings": {
+                 "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -command ', variables('doubleQuote'), '& { <%= setup_winrm_powershell %> }', variables('doubleQuote'))]"
+               }
+           }
+        }
+      ],

--- a/templates/arm/setup-winrm.ps1.erb
+++ b/templates/arm/setup-winrm.ps1.erb
@@ -1,0 +1,7 @@
+$hostname = '<%= dns_label_prefix %>.<%= location %>.cloudapp.azure.com'
+$Cert = (New-SelfSignedCertificate -CertstoreLocation Cert:/LocalMachine/My -DnsName $hostname).Thumbprint
+$transport = New-Item -Path WSMan:/LocalHost/Listener -Transport HTTPS -Address * -CertificateThumbPrint $Cert -Force
+cd $transport.PSPath
+set-item  ./HostName -value $hostname -force
+set-item  ./Port -value <%= winrm_port %> -force
+netsh advfirewall firewall add rule name=WinRM_HTTPS dir=in action=allow protocol=TCP localport=<%= winrm_port %>


### PR DESCRIPTION
This PR builds on top of the excellent work by @rysweet in #115, and finishes off the WinRM support.

Its still a work in progress, but the basics are working.

Things that are outstanding:
- [x] WinRM port hardcoded to 5986
- [x] WinRM transport is hardcoded to ssl
- [x] WinRM ssl peer verification is hardcoded to false
- [ ] The retrying message is not translated correctly
- [x] Template is hardcoded to install self-signed cert on port 5986 using files downloaded from github
- [ ] Config validation needs updating