### PR TITLE
#161 Allow the creation of custom (opened) TCP endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ modules/
 .ruby-version
 *.ps1
 .env
+.bundle
+

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For instructions on how to setup an Azure Active Directory Application see: <htt
 * `vm_image_urn`: (Optional) Name of the virtual machine image urn to use -- defaults to 'canonical:ubuntuserver:16.04-LTS:latest'. See documentation for [*nix](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-ps-findimage/), [Windows](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-cli-ps-findimage).
 * `virtual_network_name`: (Optional) Name of the virtual network resource
 * `subnet_name`: (Optional) Name of the virtual network subnet resource
+* `tcp_endpoints`: (Optional) The custom inbound security rules part of network security group (a.k.a. opened tcp endpoints). Allows specifying one or more intervals in the form '8000-9000, 9100-9200'.
 * `instance_ready_timeout`: (Optional) The timeout to wait for an instance to become ready -- default 120 seconds.
 * `instance_check_interval`: (Optional) The interval to wait for checking an instance's state -- default 2 seconds.
 * `endpoint`: (Optional) The Azure Management API endpoint -- default `ENV['AZURE_MANAGEMENT_ENDPOINT']` if exists, falls back to <https://management.azure.com>.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ For instructions on how to setup an Azure Active Directory Application see: <htt
 * `vm_image_urn`: (Optional) Name of the virtual machine image urn to use -- defaults to 'canonical:ubuntuserver:16.04-LTS:latest'. See documentation for [*nix](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-ps-findimage/), [Windows](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-cli-ps-findimage).
 * `virtual_network_name`: (Optional) Name of the virtual network resource
 * `subnet_name`: (Optional) Name of the virtual network subnet resource
-* `tcp_endpoints`: (Optional) The custom inbound security rules part of network security group (a.k.a. opened tcp endpoints). Allows specifying one or more intervals in the form '8000-9000, 9100-9200'.
+* `tcp_endpoints`: (Optional) The custom inbound security rules part of network security group (a.k.a. opened tcp endpoints). Allows specifying one or more intervals in the form of:
+ * an array `['8000-9000', '9100-9200']`, 
+ * a single interval as `'8000-9000'`,
+ * a single port as `8000`.
 * `instance_ready_timeout`: (Optional) The timeout to wait for an instance to become ready -- default 120 seconds.
 * `instance_check_interval`: (Optional) The interval to wait for checking an instance's state -- default 2 seconds.
 * `endpoint`: (Optional) The Azure Management API endpoint -- default `ENV['AZURE_MANAGEMENT_ENDPOINT']` if exists, falls back to <https://management.azure.com>.

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -124,6 +124,13 @@ module VagrantPlugins
             deployment_params.merge!(windows_params)
           end
 
+          unless tcp_endpoints.nil? || tcp_endpoints.empty?
+            endpoints = tcp_endpoints.split(',')
+          else 
+            endpoints = {}
+          end
+          template_params.merge!(endpoints: endpoints)
+
           env[:ui].info(" -- Create or Update of Resource Group: #{resource_group_name}")
           env[:metrics]['put_resource_group'] = Util::Timer.time do
             put_resource_group(azure, resource_group_name, location)

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -124,10 +124,21 @@ module VagrantPlugins
             deployment_params.merge!(windows_params)
           end
 
-          unless tcp_endpoints.nil? || tcp_endpoints.empty?
-            endpoints = tcp_endpoints.split(',')
+          unless tcp_endpoints.nil?
+
+            if tcp_endpoints.is_a?(Array)
+              # https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-nsg#Nsg-rules
+              if tcp_endpoints.length + 133 > 4096
+                raise I18n.t('vagrant_azure.too_many_tcp_endpoints', count: tcp_endpoints.length)
+              end 
+              endpoints = tcp_endpoints
+            elsif tcp_endpoints.is_a?(String) || (tcp_endpoints.is_a?(Integer) && tcp_endpoints > 0)
+              endpoints = [tcp_endpoints]
+            else
+              raise I18n.t('vagrant_azure.unknown_type_as_tcp_endpoints', input: tcp_endpoints)
+            end
           else 
-            endpoints = {}
+            endpoints = []
           end
           template_params.merge!(endpoints: endpoints)
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -104,6 +104,12 @@ en:
       Please specify a secure key to use with config.ssh.private_key_path
       (see: https://www.vagrantup.com/docs/vagrantfile/ssh_settings.html).
       If not, you publicly accessible Azure VM will be extremely insecure.
+    too_many_tcp_endpoints: |-
+      There are '%{count}' TCP Endpoints (Inbound Security Rules) specified for the NetworkSecurityGroup, which is too many. 
+      There can be a max of 3963 (4096 - 133, where 133 is where we start as priority for custom rule #1, and so forth)
+      (see: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-nsg#Nsg-rules)
+    unknown_type_as_tcp_endpoints: |-
+      Unrecognized setting '%{input}' as TCP Endpoints (Inbounds Security Rules), expected an array, string or positive number.
     waiting_for_ready: |-
       Waiting for instance to become "ready"...
     waiting_for_stop: |-

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -173,7 +173,24 @@
               "direction": "Inbound"
             }
           }
-          <% end %>
+        <% end %>
+        <% endpoints.each_with_index do |ports, index| %>
+          ,
+          {
+            "name": "custom_rule_<%= index %>",
+            "properties": {
+              "description": "Custom opened ports.",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "<%= ports %>",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": <%= 133 + index %>,
+              "direction": "Inbound"
+            }
+          }
+        <% end %>
         ]
       }
     },


### PR DESCRIPTION
This enables the setup of custom opened ports. 
At the moment it allows only one interval.

In the future it should support multiple port intervals (comma separated).
