### PR TITLE
Adding telemetry information for vagrant-azure into azure_mgmt_* sdks

### DIFF
--- a/lib/vagrant-azure/services/azure_resource_manager.rb
+++ b/lib/vagrant-azure/services/azure_resource_manager.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
     module Services
       class AzureResourceManager
 
+        TELEMETRY = "vagrant-azure/#{VagrantPlugins::Azure::VERSION}"
         TENANT_ID_NAME = 'AZURE_TENANT_ID'
         CLIENT_ID_NAME = 'AZURE_CLIENT_ID'
         CLIENT_SECRET_NAME = 'AZURE_CLIENT_SECRET'
@@ -68,6 +69,7 @@ module VagrantPlugins
         def build(clazz)
           instance = clazz.new(*client_params)
           instance.subscription_id = @subscription_id
+          instance.add_user_agent_information(TELEMETRY)
           instance
         end
 


### PR DESCRIPTION
To enhance telemetry and data collection for third party plug-ins of azure_mgmt_*, this PR adds telemetry information.  https://github.com/Azure/azure-sdk-for-ruby/issues/517