### PR TITLE
Added parameters: dns label prefix and network security group label p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ For instructions on how to setup an Azure Active Directory Application see: <htt
 * `vm_size`: (Optional) VM size to be used -- defaults to 'Standard_DS2_v2'. See sizes for [*nix](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/), [Windows](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-sizes/).
 * `vm_image_urn`: (Optional) Name of the virtual machine image urn to use -- defaults to 'canonical:ubuntuserver:16.04-LTS:latest'. See documentation for [*nix](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-ps-findimage/), [Windows](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-cli-ps-findimage).
 * `virtual_network_name`: (Optional) Name of the virtual network resource
+* `dns_name`: (Optional) DNS Label Prefix 
+* `nsg_name`: (Optional) Network Security Group Label Prefix 
 * `subnet_name`: (Optional) Name of the virtual network subnet resource
 * `tcp_endpoints`: (Optional) The custom inbound security rules part of network security group (a.k.a. opened tcp endpoints). Allows specifying one or more intervals in the form of:
   * an array `['8000-9000', '9100-9200']`, 

--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
 
           # Get the configs
           config                         = machine.provider_config
+
+          config.dns_name ||= Haikunator.haikunate(100)
+          config.nsg_name ||= config.vm_name
+
           endpoint                       = config.endpoint
           resource_group_name            = config.resource_group_name
           location                       = config.location
@@ -45,7 +49,8 @@ module VagrantPlugins
           admin_password                 = config.admin_password
           winrm_port                     = machine.config.winrm.port
           winrm_install_self_signed_cert = config.winrm_install_self_signed_cert
-          dns_label_prefix               = Haikunator.haikunate(100)
+          dns_label_prefix               = config.dns_name
+          nsg_label_prefix               = config.nsg_name
           deployment_template            = config.deployment_template
 
           # Launch!
@@ -76,6 +81,7 @@ module VagrantPlugins
 
           deployment_params = {
             dnsLabelPrefix:       dns_label_prefix,
+            nsgLabelPrefix:       nsg_label_prefix,
             vmSize:               vm_size,
             vmName:               vm_name,
             imagePublisher:       image_publisher,
@@ -95,6 +101,7 @@ module VagrantPlugins
             winrm_install_self_signed_cert: winrm_install_self_signed_cert,
             winrm_port:                     winrm_port,
             dns_label_prefix:               dns_label_prefix,
+            nsg_label_prefix:               nsg_label_prefix,
             location:                       location,
             deployment_template:            deployment_template
           }

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -43,6 +43,16 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :vm_name
 
+      # (Optional) DNS Name prefix of the virtual machine
+      #
+      # @return [String]
+      attr_accessor :dns_name
+
+      # (Optional) Network Security Group Name prefix of the virtual machine
+      #
+      # @return [String]
+      attr_accessor :nsg_name
+
       # Password for the VM -- This is not recommended for *nix deployments
       #
       # @return [String]
@@ -131,6 +141,8 @@ module VagrantPlugins
         @vm_image_urn = UNSET_VALUE
         @virtual_network_name = UNSET_VALUE
         @subnet_name = UNSET_VALUE
+        @dsn_name = UNSET_VALUE
+        @nsg_name = UNSET_VALUE
         @tcp_endpoints = UNSET_VALUE
         @vm_size = UNSET_VALUE
         @availability_set_name = UNSET_VALUE
@@ -157,6 +169,8 @@ module VagrantPlugins
         @location = 'westus' if @location == UNSET_VALUE
         @virtual_network_name = nil if @virtual_network_name == UNSET_VALUE
         @subnet_name = nil if @subnet_name == UNSET_VALUE
+        @dns_name = nil if @dns_name == UNSET_VALUE
+        @nsg_name = nil if @nsg_name == UNSET_VALUE
         @tcp_endpoints = nil if @tcp_endpoints == UNSET_VALUE
         @vm_size = 'Standard_DS2_v2' if @vm_size == UNSET_VALUE
         @availability_set_name = nil if @availability_set_name == UNSET_VALUE

--- a/templates/arm/deployment.json.erb
+++ b/templates/arm/deployment.json.erb
@@ -30,6 +30,12 @@
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
+    "nsgLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Network Security Group Label Prefix for the Virtual Machine."
+      }
+    },
     "vmSize": {
       "type": "string",
       "defaultValue": "Standard_DS2_v2",
@@ -104,7 +110,7 @@
     "publicIPAddressName": "[concat(parameters('vmName'), '-vagrantPublicIP')]",
     "publicIPAddressType": "Dynamic",
     "storageAccountType": "Premium_LRS",
-    "networkSecurityGroupName": "[concat(parameters('vmName'), '-vagrantNSG')]",
+    "networkSecurityGroupName": "[concat(parameters('nsgLabelPrefix'), '-vagrantNSG')]",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",


### PR DESCRIPTION
Hi, 

I'm experiencing few troubles creating a cluster. 

I need to specify the domain label prefix which now is create randomly by `Haikunator`
I need to specify the subnet and the network security group. Now is create a new security group for each vm within the same subnet (using the vm_name as prefix), but a subnet can have only one security group (so most of them are useless).

So I've added two optional parameters dns_name and nsg_name, if they are not specified the default behaviour remains unchanged.

So these parameters add the option to specify domain label prefix (dns_name) and network security group name prefix (nsg_name).


