### PR TITLE
lock down to faraday 0.11.0

### DIFF
--- a/vagrant-azure.gemspec
+++ b/vagrant-azure.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'azure_mgmt_compute',    '~>0.8.0'
   s.add_runtime_dependency 'azure_mgmt_network',    '~>0.8.0'
   s.add_runtime_dependency 'azure_mgmt_storage',    '~>0.8.0'
+  s.add_runtime_dependency 'faraday',               '~>0.11.0'
   s.add_runtime_dependency 'haikunator',            '~>1.1'
   s.add_runtime_dependency 'highline',              '~>1.7'
 


### PR DESCRIPTION
fixes #182 

Faraday change for nil handling broke our world. This change is only until ms_rest is updated.