### PR TITLE
Add support for config.vm_storage_account_type.

### DIFF
--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -40,6 +40,7 @@ module VagrantPlugins
           location                       = config.location
           ssh_user_name                  = machine.config.ssh.username
           vm_name                        = config.vm_name
+          vm_storage_account_type        = config.vm_storage_account_type
           vm_size                        = config.vm_size
           vm_image_urn                   = config.vm_image_urn
           vm_vhd_uri                     = config.vm_vhd_uri
@@ -65,6 +66,7 @@ module VagrantPlugins
           env[:ui].info(" -- SSH User Name: #{ssh_user_name}") if ssh_user_name
           env[:ui].info(" -- Admin Username: #{admin_user_name}") if admin_user_name
           env[:ui].info(" -- VM Name: #{vm_name}")
+          env[:ui].info(" -- VM Storage Account Type: #{vm_storage_account_type}")
           env[:ui].info(" -- VM Size: #{vm_size}")
 
           if !vm_vhd_uri.nil?
@@ -91,6 +93,7 @@ module VagrantPlugins
             dnsLabelPrefix:       dns_label_prefix,
             nsgLabelPrefix:       nsg_label_prefix,
             vmSize:               vm_size,
+            storageAccountType:   vm_storage_account_type,
             vmName:               vm_name,
             subnetName:           subnet_name,
             virtualNetworkName:   virtual_network_name,

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -46,6 +46,12 @@ module VagrantPlugins
       attr_accessor :vm_name
 
       # (Optional) DNS Name prefix of the virtual machine
+      # Uses value of vm_name if not specified.
+      # Note: this must conform to the following regular expression:
+      #
+      #    ^[a-z][a-z0-9-]{1,61}[a-z0-9]
+      #
+      # Therefore this field mustbe set if vm_name has capital letters (for ex.)
       #
       # @return [String]
       attr_accessor :dns_name

--- a/lib/vagrant-azure/config.rb
+++ b/lib/vagrant-azure/config.rb
@@ -65,6 +65,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :vm_size
 
+      # (Optional) Storage account type to be used -- defaults to 'Premium_LRS'. Alt value is 'Standard_LRS' See: https://docs.microsoft.com/en-us/azure/storage/storage-about-disks-and-vhds-linux
+      #
+      # @return [String]
+      attr_accessor :vm_storage_account_type
+
       # (Optional) Name of the virtual machine image URN to use -- defaults to 'canonical:ubuntuserver:16.04.0-DAILY-LTS:latest'. See: https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-ps-findimage/
       #
       # @return [String]
@@ -193,6 +198,7 @@ module VagrantPlugins
         @nsg_name = UNSET_VALUE
         @tcp_endpoints = UNSET_VALUE
         @vm_size = UNSET_VALUE
+        @vm_storage_account_type = UNSET_VALUE
         @availability_set_name = UNSET_VALUE
         @instance_ready_timeout = UNSET_VALUE
         @instance_check_interval = UNSET_VALUE
@@ -228,6 +234,7 @@ module VagrantPlugins
         @dns_name = nil if @dns_name == UNSET_VALUE
         @nsg_name = nil if @nsg_name == UNSET_VALUE
         @tcp_endpoints = nil if @tcp_endpoints == UNSET_VALUE
+        @vm_storage_account_type = 'Premium_LRS' if @vm_storage_account_type == UNSET_VALUE
         @availability_set_name = nil if @availability_set_name == UNSET_VALUE
 
         @instance_ready_timeout = 120 if @instance_ready_timeout == UNSET_VALUE


### PR DESCRIPTION
Allow use of `config.vm_storage_account_type = 'Standard_LRS'` to override the default storage level of Premium_LRS, so that the plugin can be used to deploy Basic_A0 azure instances that are not otherwise allowed.