### PR TITLE
Fix for tcp_endpoints

### DIFF
--- a/lib/vagrant-azure/version.rb
+++ b/lib/vagrant-azure/version.rb
@@ -4,6 +4,6 @@
 
 module VagrantPlugins
   module Azure
-    VERSION = '2.0.0.pre8-nsg-fix'.freeze
+    VERSION = '2.0.0.pre8nsgfix'.freeze
   end
 end

--- a/lib/vagrant-azure/version.rb
+++ b/lib/vagrant-azure/version.rb
@@ -4,6 +4,6 @@
 
 module VagrantPlugins
   module Azure
-    VERSION = '2.0.0.pre8'.freeze
+    VERSION = '2.0.0.pre8-nsg-fix'.freeze
   end
 end

--- a/templates/arm/resources/network_security_group.json.erb
+++ b/templates/arm/resources/network_security_group.json.erb
@@ -55,28 +55,14 @@
           "name": "custom_rule_inbound_<%= index %>",
           "properties": {
             "description": "Enable inbound custom ports.",
-            "protocol": "*",
-            "sourcePortRange": "<%= ports %>",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
             "destinationPortRange": "<%= ports %>",
             "sourceAddressPrefix": "*",
             "destinationAddressPrefix": "*",
             "access": "Allow",
             "priority": <%= 133 + index %>,
             "direction": "Inbound"
-          }
-        },
-        {
-          "name": "custom_rule_outbound_<%= index %>",
-          "properties": {
-            "description": "Enabled outbound custom ports.",
-            "protocol": "*",
-            "sourcePortRange": "<%= ports %>",
-            "destinationPortRange": "<%= ports %>",
-            "sourceAddressPrefix": "*",
-            "destinationAddressPrefix": "*",
-            "access": "Allow",
-            "priority": <%= 134 + index %>,
-            "direction": "Outbound"
           }
         }
       <% end %>


### PR DESCRIPTION
tcp_endpoints doesn't work as anticipated. Currently, the NSG template sets the source port to the same setting as the destination port, which causes connections to fail. The version in the pull request sets the source port to '*', which is most likely what was intended. Also, the outbound rules aren't necessary and the protocol is set to '*', which is odd given that the option is called tcp_endpoints.