### PR TITLE
`azure.vm_image_urn` supersedes `config.vm.box`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ end
 #### Windows Vagrantfile
 ```ruby
 Vagrant.configure('2') do |config|
-  config.vm.box = 'azure'
-
   config.vm.provider :azure do |azure, override|
 
     # each of the below values will default to use the env vars named as below if not specified explicitly


### PR DESCRIPTION
Thus either you use one or the other. Probably much more convenient to use the former, which is why I have deleted the latter.